### PR TITLE
Prepare model training examples

### DIFF
--- a/examples/simple_predict.py
+++ b/examples/simple_predict.py
@@ -1,0 +1,75 @@
+# We need to add the unetpp package to the system path so that we can import it
+import sys
+from pathlib import PurePath
+
+unetpp_path = PurePath(__file__).parent.parent
+sys.path.append(str(unetpp_path))
+
+# Import the necessary packages
+from unetpp.model.unetpp import UNetPlusPlus
+from unetpp.utils.functions import dice_coefficient
+from unetpp.utils.images import (
+    split_mask_into_binary,
+    join_binary_masks,
+    softmax_to_argmax,
+)
+from unetpp.generators.default import SegmentationGenerator
+from keras.saving import load_model
+from PIL import Image
+
+from datetime import datetime
+
+
+NOW_STR = datetime.now().strftime("%y%m%d_%H%M%S")
+
+# Replace the following paths with the actual paths
+MODEL_PATH = "path/to/model/folder/with.model.hdf5"
+IMAGE_PATH = "path/to/image.png"
+MASK_PATH = "path/to/mask.png"
+
+INPUT_SHAPE = (256, 512, 3)  # (height, width, channels)
+
+# We assume the model was trained on the classes [0, 24, 26] (background, person, car)
+CLASSES = [0, 24, 26]
+
+
+# Load model
+model = load_model(MODEL_PATH, custom_objects={"dice_coefficient": dice_coefficient})
+
+# When loding checkpoints, use the following code instead
+"""
+model = UNetPlusPlus(INPUT_SHAPE, 3).model
+model.load_weights(MODEL_PATH)
+"""
+
+# Load image and mask for prediction (and comparison)
+image = SegmentationGenerator.read_image_and_resize(IMAGE_PATH, 3, INPUT_SHAPE[:2])
+mask = SegmentationGenerator.read_image_and_resize(MASK_PATH, 1, INPUT_SHAPE[:2])
+mask = split_mask_into_binary(mask, CLASSES)
+
+# Predict
+pred = model.predict(image.reshape(1, *INPUT_SHAPE))[0]
+pred = softmax_to_argmax(pred)
+pred = join_binary_masks(pred, CLASSES)
+pred = pred.astype("uint8")
+
+# Save the input image, mask and prediction
+image = image.astype("uint8")
+input_image = Image.fromarray(image)
+
+mask = join_binary_masks(mask, CLASSES)
+mask = (mask * [1, 1, 1]).astype("uint8")
+input_mask = Image.fromarray(mask)
+
+pred = (pred * [1, 1, 1]).astype("uint8")
+pred_mask = Image.fromarray(pred)
+
+# Join the images from left to right
+# Add a white line (2px) between all images
+joined_image = Image.new("RGB", (3 * INPUT_SHAPE[1] + 2 * 2, INPUT_SHAPE[0]), "white")
+joined_image.paste(input_image, (0, 0))
+joined_image.paste(input_mask, (INPUT_SHAPE[1] + 2, 0))
+joined_image.paste(pred_mask, (2 * INPUT_SHAPE[1] + 2 * 2, 0))
+
+# Save the joined image
+joined_image.save(f"result_{NOW_STR}.png")

--- a/examples/simple_train.py
+++ b/examples/simple_train.py
@@ -1,0 +1,97 @@
+# We need to add the unetpp package to the system path so that we can import it
+import sys
+from pathlib import PurePath
+
+unetpp_path = PurePath(__file__).parent.parent
+sys.path.append(str(unetpp_path))
+
+# Import the necessary packages
+from unetpp.model.unetpp import UNetPlusPlus
+from unetpp.generators.default import SegmentationGenerator
+from unetpp.utils.images import get_image_mask_pair_paths
+from unetpp.utils.functions import dice_coefficient
+from unetpp.utils.datasets import train_test_val_split
+
+from keras.optimizers import Adam
+from keras.callbacks import EarlyStopping, ModelCheckpoint
+
+from datetime import datetime
+
+# Replace the following paths with the actual paths
+DATASET_FOLDER_PATH = "path/to/dataset/folder"
+CHECKPOINT_FOLDER_PATH = "path/to/checkpoint/folder"
+MODEL_FOLDER_PATH = "path/to/model/folder"
+
+EPOCHS = 60
+INPUT_SHAPE = (128, 256, 3)  # (height, width, channels)
+COLORMAPS = [0, 24, 26]  # Colormaps for the masks / classes / labels
+
+NOW_STR = datetime.now().strftime("%y%m%d_%H%M%S")
+
+# Build the model and print the summary
+model = UNetPlusPlus(INPUT_SHAPE, len(COLORMAPS)).model
+model.summary()
+
+# Get image/mask paths
+paths = get_image_mask_pair_paths(PurePath(DATASET_FOLDER_PATH))
+
+# Split the paths into training, validation and test sets
+train_paths, val_paths, test_paths = train_test_val_split(
+    paths, train_ratio=0.7, val_ratio=0.2, test_ratio=0.1
+)
+
+# Create a generators
+train_generator = SegmentationGenerator(
+    train_paths,
+    colormap=COLORMAPS,
+    target_size=INPUT_SHAPE[:2],
+    batch_size=16,
+    shuffle=True,
+)
+validation_generator = SegmentationGenerator(
+    val_paths,
+    colormap=COLORMAPS,
+    target_size=INPUT_SHAPE[:2],
+    batch_size=16,
+    shuffle=True,
+)
+
+# Choose an optimizer (default settings)
+optimizer = Adam()
+
+# Compile the model
+model.compile(
+    optimizer=optimizer, loss="categorical_crossentropy", metrics=[dice_coefficient]
+)
+
+# Create a ModelCheckpoint callback
+cp_filename = str(
+    PurePath(CHECKPOINT_FOLDER_PATH) / f"unetpp_{NOW_STR}" / f"weights_{NOW_STR}.hdf5"
+)
+model_checkpoint_callback = ModelCheckpoint(
+    filepath=cp_filename,
+    save_weights_only=True,
+    monitor="val_loss",
+    mode="min",
+    save_best_only=True,
+    verbose=1,
+)
+
+# Create an EarlyStopping callback
+early_stopping_callback = EarlyStopping(
+    monitor="val_loss", patience=6, mode="min", verbose=1, restore_best_weights=True
+)
+
+# Train the model
+history = model.fit(
+    train_generator,
+    epochs=EPOCHS,
+    steps_per_epoch=train_generator.steps_per_epoch,
+    validation_data=validation_generator,
+    validation_steps=validation_generator.steps_per_epoch,
+    callbacks=[model_checkpoint_callback, early_stopping_callback],
+)
+
+# Save the model
+m_path = str(PurePath(MODEL_FOLDER_PATH) / f"unetpp_{NOW_STR}.h5")
+model.save(m_path)

--- a/unetpp/examples.py
+++ b/unetpp/examples.py
@@ -1,7 +1,0 @@
-from model.unetpp import UNetPlusPlus
-
-# Build the model and print the summary
-input_shape = (256, 256, 3)
-num_classes = 1
-model = UNetPlusPlus(input_shape, num_classes).model
-model.summary()

--- a/unetpp/generators/default.py
+++ b/unetpp/generators/default.py
@@ -5,7 +5,7 @@ from keras.preprocessing.image import load_img, img_to_array
 from typing import Tuple
 
 
-from utils.images import ImageMaskPairPaths, split_mask_into_binary
+from unetpp.utils.images import ImageMaskPairPaths, split_mask_into_binary
 
 
 class SegmentationGenerator(Sequence):

--- a/unetpp/utils/datasets.py
+++ b/unetpp/utils/datasets.py
@@ -1,0 +1,38 @@
+from unetpp.utils.images import ImageMaskPairPaths
+
+from typing import List, Tuple
+import numpy as np
+
+
+def train_test_val_split(
+    paths: List[ImageMaskPairPaths],
+    train_ratio: float = 0.7,
+    val_ratio: float = 0.2,
+    test_ratio: float = 0.1,
+    shuffle: bool = True,
+    random_state: int = 42,
+) -> Tuple[
+    List[ImageMaskPairPaths], List[ImageMaskPairPaths], List[ImageMaskPairPaths]
+]:
+    # Ensure that the ratios are valid
+    tolerance = 1e-7
+    if abs((train_ratio + val_ratio + test_ratio) - 1) > tolerance:
+        raise ValueError("The sum of the train, validation and test ratios must be 1")
+
+    # Provide at least 10 path pairs
+    if len(paths) < 10:
+        raise ValueError("There must be at least 10 path pairs")
+
+    if shuffle:
+        np.random.seed(random_state)
+        np.random.shuffle(paths)
+
+    total_cnt = len(paths)
+    train_cnt = int(total_cnt * train_ratio)
+    val_cnt = int(total_cnt * val_ratio)
+
+    train_paths = paths[:train_cnt]
+    val_paths = paths[train_cnt : train_cnt + val_cnt]
+    test_paths = paths[train_cnt + val_cnt :]
+
+    return train_paths, val_paths, test_paths

--- a/unetpp/utils/functions.py
+++ b/unetpp/utils/functions.py
@@ -1,0 +1,9 @@
+import tensorflow as tf
+import keras.backend as kb
+
+# Source: https://github.com/maju116/pyplatypus/blob/7b1706e4d6f2ef184d0e90d87226506cebb8ed1d/pyplatypus/segmentation/loss_functions.py#L91
+def dice_coefficient(y_actual: tf.Tensor, y_pred: tf.Tensor) -> tf.Tensor:
+    intersection = kb.sum(tf.cast(y_actual, 'float32') * y_pred)
+    masks_sum = kb.sum(tf.cast(y_actual, 'float32')) + kb.sum(y_pred)
+    dice_coefficient = (2 * intersection + kb.epsilon()) / (masks_sum + kb.epsilon())
+    return dice_coefficient

--- a/unetpp/utils/images.py
+++ b/unetpp/utils/images.py
@@ -27,3 +27,12 @@ def split_mask_into_binary(mask: np.ndarray, colormap: List[int]) -> np.ndarray:
 
 def join_binary_masks(mask: np.ndarray, colormap: List[int]) -> np.ndarray:
     return np.sum([mask[..., i, None] * c for i, c in enumerate(colormap)], axis=0)
+
+def softmax_to_argmax(mask: np.ndarray) -> np.ndarray:
+    binary_mask = np.zeros_like(mask)
+    max_indices = np.argmax(mask, axis=-1)
+
+    for i in range(mask.shape[-1]):
+        binary_mask[:, :, i] = (max_indices == i).astype(int)
+
+    return binary_mask


### PR DESCRIPTION
- added simple examples on how to train a model and predicts image masks
- added function to covert a softmax-ed ndarray mask to argmax
- added the dice coefficient loss function (based on https://github.com/maju116/pyplatypus/blob/7b1706e4d6f2ef184d0e90d87226506cebb8ed1d/pyplatypus/segmentation/loss_functions.py#L91)
- added a train/test/validation split function for a list of ImageMaskPairPaths
- ensured the utility folder can be used as a module
